### PR TITLE
Added url shortcut feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+config.toml
+*.mp4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mpegdash
 tqdm
 colorama
 aiohttp
+toml

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -1,0 +1,5 @@
+# Rename to config.toml and supply valid urls for all shortcuts before use
+[shortcuts]
+
+example1 = "example_url"
+example2 = "example_url"

--- a/yt_ddl.py
+++ b/yt_ddl.py
@@ -15,6 +15,7 @@ import aiohttp
 import random
 import subprocess
 import multiprocessing
+import toml
 
 async def fetch(session, url, i, folder, pbar, sem):
     async with sem, session.get(url) as response:
@@ -145,6 +146,13 @@ def main(ffmpeg_executable):
     output_path = args.output
     start_time = None
     duration_secs = None
+
+    try:
+        CONFIG = toml.load("config.toml")
+        if url in CONFIG["shortcuts"]:
+            url = CONFIG["shortcuts"][url]
+    except (FileNotFoundError, KeyError):
+        pass
 
     def arg_fail(message):
         print(message, file=sys.stderr)


### PR DESCRIPTION
Added a feature for url shortcuts, instead of supplying the full `url`, a shortcut name can now be supplied.

Example configuration:
**config.toml**:
```toml
[shortcuts]

D105 = "example_url"
```

If you now call the program with the URL argument `D105`, the shortcut name will be substituted by the shortcut value `example_url`, if no shortcut is found, the original argument will be used.

Just remember not to accidentally push non-public urls.