### PR TITLE
Fix breaking YouTube change

### DIFF
--- a/yt_ddl/yt_ddl.py
+++ b/yt_ddl/yt_ddl.py
@@ -47,9 +47,12 @@ def local_to_utc(dt):
 
 def get_mpd_data(video_url):
     page = get(video_url).text
-    mpd_link = (
-        page.split('dashManifestUrl\\":\\"')[-1].split('\\"')[0].replace("\/", "/")
-    )
+    if 'dashManifestUrl\\":\\"' in page:
+        mpd_link = page.split('dashManifestUrl\\":\\"')[-1].split('\\"')[0].replace("\/", "/")
+    elif 'dashManifestUrl":"' in page:
+        mpd_link = page.split('dashManifestUrl":"')[-1].split('"')[0].replace("\/", "/")
+    else:
+        return None
     return get(mpd_link).text
 
 
@@ -251,6 +254,9 @@ def main(**kwargs):
     check_for_update()
 
     mpd_data = get_mpd_data(kwargs["url"])
+    if mpd_data is None:
+        print("Error: Couldn't get MPD data!")
+        return 0
     a, v, m, s, l = process_mpd(mpd_data)
 
     if kwargs["list_formats"]:


### PR DESCRIPTION
Recently, YouTube changed their HTML a bit - now the JSON which has dashManifestUrl may not be escaped, which breaks the script. 
The change is still ongoing, so the old version may still appear too.