### PR TITLE
inspect more of the mimeType field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ dependency_links = [x.strip().replace("git+", "") for x in all_reqs if "git+" no
 setup(
     name="youtube_dash_dl",
     description="Tool to download VoD of an ongoing stream without any time limitations.",
-    version="1.0.8",
+    version="1.0.9",
     packages=find_packages(),
     install_requires=install_requires,
     python_requires=">=3.6",

--- a/yt_ddl/yt_ddl.py
+++ b/yt_ddl/yt_ddl.py
@@ -96,15 +96,15 @@ def process_mpd(mpd_data):
     v_streams = []
     a_streams = []
     for a in attribute_sets:
-        stream_type = a.attrib["mimeType"][0]
+        stream_type = a.attrib["mimeType"][0:2]
         for r in a.findall(".//def:Representation", nsmap):
             bitrate = int(r.attrib["bandwidth"])
             codec = r.attrib["codecs"]
             base_url = r.find(".//def:BaseURL", nsmap).text + "sq/"
-            if stream_type == "a":
+            if stream_type == "au":
                 quality = r.attrib["audioSamplingRate"]
                 a_streams.append(Stream(stream_type, bitrate, codec, quality, base_url))
-            elif stream_type == "v":
+            elif stream_type == "vi":
                 quality = f"{r.attrib['width']}x{r.attrib['height']}"
                 v_streams.append(Stream(stream_type, bitrate, codec, quality, base_url))
     a_streams.sort(key=lambda x: x.bitrate, reverse=True)

--- a/yt_ddl/yt_ddl.py
+++ b/yt_ddl/yt_ddl.py
@@ -96,15 +96,15 @@ def process_mpd(mpd_data):
     v_streams = []
     a_streams = []
     for a in attribute_sets:
-        stream_type = a.attrib["mimeType"][0:2]
+        stream_type = a.attrib["mimeType"].split('/')[0]
         for r in a.findall(".//def:Representation", nsmap):
             bitrate = int(r.attrib["bandwidth"])
             codec = r.attrib["codecs"]
             base_url = r.find(".//def:BaseURL", nsmap).text + "sq/"
-            if stream_type == "au":
+            if stream_type == "audio":
                 quality = r.attrib["audioSamplingRate"]
                 a_streams.append(Stream(stream_type, bitrate, codec, quality, base_url))
-            elif stream_type == "vi":
+            elif stream_type == "video":
                 quality = f"{r.attrib['width']}x{r.attrib['height']}"
                 v_streams.append(Stream(stream_type, bitrate, codec, quality, base_url))
     a_streams.sort(key=lambda x: x.bitrate, reverse=True)


### PR DESCRIPTION
I was getting a stack when listing streams for the video mentioned below. It turned out to be due to a 'application/x-rawcc' mimeTyped representation. 

Solution: Inspect up to the '/' in the mimeType.

Thank you for creating this tool. It's the only one I could find that could make a clip of a YouTube livestream.

stack on main:
```bash
$ yt_ddl https://www.youtube.com/watch\?v\=g0p5Swb0bL0 -l 
Traceback (most recent call last):
  File "/Users/aerickson/yt_grady_test/ytdash/venv/bin/yt_ddl", line 33, in <module>
    sys.exit(load_entry_point('youtube-dash-dl', 'console_scripts', 'yt_ddl')())
  File "/Users/aerickson/yt_grady_test/ytdash/venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/aerickson/yt_grady_test/ytdash/venv/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/aerickson/yt_grady_test/ytdash/venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/aerickson/yt_grady_test/ytdash/venv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/aerickson/yt_grady_test/youtube_dash_dl/yt_ddl/yt_ddl.py", line 278, in main
    a, v, m, s, l = process_mpd(mpd_data)
  File "/Users/aerickson/yt_grady_test/youtube_dash_dl/yt_ddl/yt_ddl.py", line 105, in process_mpd
    quality = r.attrib["audioSamplingRate"]
  File "src/lxml/etree.pyx", line 2494, in lxml.etree._Attrib.__getitem__
KeyError: 'audioSamplingRate'
```

With this PR:

```bash
$ yt_ddl https://www.youtube.com/watch\?v\=g0p5Swb0bL0 -l
You can go back 899 hours and 28 minutes...
Download avaliable from 2022-03-28 16:07:31.582616

Audio stream ids
0:      44100 Bitrate:   144000 Codec: mp4a.40.2
1:      22050 Bitrate:    64000 Codec: mp4a.40.5

Video stream ids
0:  1920x1080 Bitrate:  5018593 Codec: avc1.640028
1:   1280x720 Bitrate:  2684050 Codec: avc1.4d401f
2:  1920x1080 Bitrate:  1816000 Codec: vp9
3:    854x480 Bitrate:  1350025 Codec: avc1.4d401f
4:   1280x720 Bitrate:  1040000 Codec: vp9
5:    640x360 Bitrate:  1008250 Codec: avc1.4d401e
6:    854x480 Bitrate:   528000 Codec: vp9
7:    426x240 Bitrate:   456228 Codec: avc1.4d4015
8:    640x360 Bitrate:   292000 Codec: vp9
9:    256x144 Bitrate:   212465 Codec: avc1.42c00b
10:    426x240 Bitrate:   166000 Codec: vp9
11:    256x144 Bitrate:   111000 Codec: vp9
```